### PR TITLE
Make the timestamp system in Activity closer to that of the Discord SDK, and more user friendly

### DIFF
--- a/examples/activity/examples/activity.rs
+++ b/examples/activity/examples/activity.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use examples_shared::{self as es, anyhow, ds, tokio, tracing};
 
 #[tokio::main]
@@ -19,7 +21,8 @@ async fn main() -> Result<(), anyhow::Error> {
             ds::activity::Assets::default()
                 .large("the".to_owned(), Some("u mage".to_owned()))
                 .small("the".to_owned(), Some("i mage".to_owned())),
-        );
+        )
+        .timestamps(Some(SystemTime::now()), None);
 
     tracing::info!(
         "updated activity: {:?}",

--- a/examples/activity/examples/activity.rs
+++ b/examples/activity/examples/activity.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 .large("the".to_owned(), Some("u mage".to_owned()))
                 .small("the".to_owned(), Some("i mage".to_owned())),
         )
-        .timestamps(Some(SystemTime::now()), None);
+        .start_timestamp(SystemTime::now());
 
     tracing::info!(
         "updated activity: {:?}",

--- a/sdk/src/activity.rs
+++ b/sdk/src/activity.rs
@@ -49,6 +49,12 @@ impl<Tz: chrono::TimeZone> IntoTimestamp for chrono::DateTime<Tz> {
     }
 }
 
+impl IntoTimestamp for i64 {
+    fn into_timestamp(self) -> i64 {
+        self
+    }
+}
+
 /// The custom art assets to be used in the user's profile when the activity
 /// is set. These assets need to be already uploaded to Discord in the application's
 /// developer settings.

--- a/sdk/src/activity.rs
+++ b/sdk/src/activity.rs
@@ -394,7 +394,6 @@ impl ActivityBuilder {
                         } else {
                             timestamps.end = Some(timestamp.into_timestamp());
                         }
-
                     }
 
                     // Create a new timestamp object and set its end
@@ -423,9 +422,11 @@ impl ActivityBuilder {
     }
 
     /// The start and end of a "game" or "session".
-    pub fn timestamps(mut self, start: Option<impl IntoTimestamp>, end: Option<impl IntoTimestamp>) -> Self
-    
-    {
+    pub fn timestamps(
+        mut self,
+        start: Option<impl IntoTimestamp>,
+        end: Option<impl IntoTimestamp>,
+    ) -> Self {
         if let Some(st) = start {
             self = self.start_timestamp(st);
         }

--- a/sdk/src/activity.rs
+++ b/sdk/src/activity.rs
@@ -423,7 +423,6 @@ impl ActivityBuilder {
     }
 
     /// The start and end of a "game" or "session".
-    #[deprecated(note = "Use start_timestamp and end_timestamp instead")]
     pub fn timestamps(mut self, start: Option<impl IntoTimestamp>, end: Option<impl IntoTimestamp>) -> Self
     
     {


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

After working with this crate in a recent project, the largest headache I encountered was the lack of ability to set *just* a start timestamp on activity (to get the `(xx:xx elapsed)` message in my status).

This PR adds two new methods to `ActivityBuilder` and slightly changes `IntoTimestamp` and `Timestamps` to add this ability.

I have added `ActivityBuilder::start_timestamp` and `ActivityBuilder::end_timestamp` which both set *only* their respective timestamp values when called. ~~I have also deprecated `ActivityBuilder::timestamps` (although this can be undone)~~, and changed its code to just call `start_timestamp` and `end_timestamp`. (Important note, calling both methods together will set a time range, like `timestamps` does)

Both the `start_timestamp` and `end_timestamp` now take a generic `T: IntoTimestamp` instead of an `impl IntoTimestamp` since the Rust compiler seems to dislike the old way, throwing errors when the method is called.

I have added an `IntoTimestamp` impl for `i64`, so crate users can easily enter a unix timestamp as an integer (more useful for testing than anything).

Finally, to make setting only one timestamp at a time possible, I have added serde annotations to `Timestamps` to skip serialization of empty fields.

I'll be keeping an eye on this PR for any requested changes, or comments.

### Related Issues

*None*
