### PR TITLE
Add deprecation warning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ An (unofficial) open source Rust implementation of the [Discord Game SDK](https:
 
 ### TODO: [Applications](https://discord.com/developers/docs/game-sdk/applications)
 
-### TODO: [Voice](https://discord.com/developers/docs/game-sdk/discord-voice)
+### :warning: [Voice](https://discord.com/developers/docs/game-sdk/discord-voice)
 
 ### TODO: [Images](https://discord.com/developers/docs/game-sdk/images)
 
-### [Lobbies](https://discord.com/developers/docs/game-sdk/lobbies)
+### :warning: [Lobbies](https://discord.com/developers/docs/game-sdk/lobbies)
 
 #### Commands
 
@@ -80,7 +80,7 @@ An (unofficial) open source Rust implementation of the [Discord Game SDK](https:
 
 - [ ] [Integrated Networking](https://discord.com/developers/docs/game-sdk/lobbies#integrated-networking)
 
-### TODO: [Networking](https://discord.com/developers/docs/game-sdk/networking)
+### :warning: [Networking](https://discord.com/developers/docs/game-sdk/networking)
 
 ### [Overlay](https://discord.com/developers/docs/game-sdk/overlay)
 
@@ -119,12 +119,16 @@ Also note, the SDK itself and its documentation uses the utterly confusing termi
 
 #### Commands
 
-- [ ] [Get Current User](https://discord.com/developers/docs/game-sdk/users#getcurrentuser)
+- [x] [Get Current User](https://discord.com/developers/docs/game-sdk/users#getcurrentuser)
 - [ ] [Get User](https://discord.com/developers/docs/game-sdk/users#getuser)
 
 #### Events
 
 - [x] [Current User Update](https://discord.com/developers/docs/game-sdk/users#oncurrentuserupdate)
+
+### :warning: Deprecation
+
+This hasn't been officially announced by Discord yet, but the [Voice](#voice), [Lobbies](#lobbies), and [Networking](#networking) functionality will be deprecated and removed sometime in the future. Since only the lobbies functionality has been implemented thusfar, we will mark that functionality as [`deprecated`](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute) once it is official.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ An (unofficial) open source Rust implementation of the [Discord Game SDK](https:
 
 ### TODO: [Applications](https://discord.com/developers/docs/game-sdk/applications)
 
-### :warning: [Voice](https://discord.com/developers/docs/game-sdk/discord-voice)
+### ⚠️ [Voice](https://discord.com/developers/docs/game-sdk/discord-voice)
 
 ### TODO: [Images](https://discord.com/developers/docs/game-sdk/images)
 
-### :warning: [Lobbies](https://discord.com/developers/docs/game-sdk/lobbies)
+### ⚠️ [Lobbies](https://discord.com/developers/docs/game-sdk/lobbies)
 
 #### Commands
 
@@ -80,7 +80,7 @@ An (unofficial) open source Rust implementation of the [Discord Game SDK](https:
 
 - [ ] [Integrated Networking](https://discord.com/developers/docs/game-sdk/lobbies#integrated-networking)
 
-### :warning: [Networking](https://discord.com/developers/docs/game-sdk/networking)
+### ⚠️ [Networking](https://discord.com/developers/docs/game-sdk/networking)
 
 ### [Overlay](https://discord.com/developers/docs/game-sdk/overlay)
 
@@ -126,7 +126,7 @@ Also note, the SDK itself and its documentation uses the utterly confusing termi
 
 - [x] [Current User Update](https://discord.com/developers/docs/game-sdk/users#oncurrentuserupdate)
 
-### :warning: Deprecation
+### ⚠️ Deprecation
 
 This hasn't been officially announced by Discord yet, but the [Voice](#voice), [Lobbies](#lobbies), and [Networking](#networking) functionality will be deprecated and removed sometime in the future. Since only the lobbies functionality has been implemented thusfar, we will mark that functionality as [`deprecated`](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute) once it is official.
 
@@ -159,14 +159,14 @@ We welcome community contributions to this project.
 Please read our [Contributor Guide](CONTRIBUTING.md) for more information on how to get started.
 Please also read our [Contributor Terms](CONTRIBUTING.md/#Contributor-Terms) before you make any contributions.
 
-Any contribution intentionally submitted for inclusion in an Embark Studios project, shall comply with the Rust standard licensing model (MIT + Apache 2.0) and therefore be dual licensed as described below, without any additional terms or conditions:
+Any contribution intentionally submitted for inclusion in an Embark Studios project, shall comply with the Rust standard licensing model (MIT OR Apache 2.0) and therefore be dual licensed as described below, without any additional terms or conditions:
 
 ### License
 
-This [contribution] is dual licensed under EITHER OF
+This contribution is dual licensed under EITHER OF
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -47,11 +47,11 @@ An (unofficial) open source Rust implementation of the [Discord Game SDK](https:
 
 ### TODO: [Applications](https://discord.com/developers/docs/game-sdk/applications)
 
-### TODO: [Voice](https://discord.com/developers/docs/game-sdk/discord-voice)
+### :warning: [Voice](https://discord.com/developers/docs/game-sdk/discord-voice)
 
 ### TODO: [Images](https://discord.com/developers/docs/game-sdk/images)
 
-### [Lobbies](https://discord.com/developers/docs/game-sdk/lobbies)
+### :warning: [Lobbies](https://discord.com/developers/docs/game-sdk/lobbies)
 
 #### Commands
 
@@ -80,7 +80,7 @@ An (unofficial) open source Rust implementation of the [Discord Game SDK](https:
 
 - [ ] [Integrated Networking](https://discord.com/developers/docs/game-sdk/lobbies#integrated-networking)
 
-### TODO: [Networking](https://discord.com/developers/docs/game-sdk/networking)
+### :warning: [Networking](https://discord.com/developers/docs/game-sdk/networking)
 
 ### [Overlay](https://discord.com/developers/docs/game-sdk/overlay)
 
@@ -125,6 +125,10 @@ Also note, the SDK itself and its documentation uses the utterly confusing termi
 #### Events
 
 - [x] [Current User Update](https://discord.com/developers/docs/game-sdk/users#oncurrentuserupdate)
+
+### :warning:
+
+This hasn't been officially announced by Discord yet, but the [Voice](#voice), [Lobbies](#lobbies), and [Networking](#networking) functionality will be deprecated and removed sometime in the future. Since only the lobbies functionality has been implemented thusfar, we will mark that functionality as [`deprecated`](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute) once it is official.
 
 ## Testing
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -119,14 +119,14 @@ Also note, the SDK itself and its documentation uses the utterly confusing termi
 
 #### Commands
 
-- [ ] [Get Current User](https://discord.com/developers/docs/game-sdk/users#getcurrentuser)
+- [x] [Get Current User](https://discord.com/developers/docs/game-sdk/users#getcurrentuser)
 - [ ] [Get User](https://discord.com/developers/docs/game-sdk/users#getuser)
 
 #### Events
 
 - [x] [Current User Update](https://discord.com/developers/docs/game-sdk/users#oncurrentuserupdate)
 
-### :warning:
+### :warning: Deprecation
 
 This hasn't been officially announced by Discord yet, but the [Voice](#voice), [Lobbies](#lobbies), and [Networking](#networking) functionality will be deprecated and removed sometime in the future. Since only the lobbies functionality has been implemented thusfar, we will mark that functionality as [`deprecated`](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute) once it is official.
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -47,11 +47,11 @@ An (unofficial) open source Rust implementation of the [Discord Game SDK](https:
 
 ### TODO: [Applications](https://discord.com/developers/docs/game-sdk/applications)
 
-### :warning: [Voice](https://discord.com/developers/docs/game-sdk/discord-voice)
+### ⚠️ [Voice](https://discord.com/developers/docs/game-sdk/discord-voice)
 
 ### TODO: [Images](https://discord.com/developers/docs/game-sdk/images)
 
-### :warning: [Lobbies](https://discord.com/developers/docs/game-sdk/lobbies)
+### ⚠️ [Lobbies](https://discord.com/developers/docs/game-sdk/lobbies)
 
 #### Commands
 
@@ -80,7 +80,7 @@ An (unofficial) open source Rust implementation of the [Discord Game SDK](https:
 
 - [ ] [Integrated Networking](https://discord.com/developers/docs/game-sdk/lobbies#integrated-networking)
 
-### :warning: [Networking](https://discord.com/developers/docs/game-sdk/networking)
+### ⚠️ [Networking](https://discord.com/developers/docs/game-sdk/networking)
 
 ### [Overlay](https://discord.com/developers/docs/game-sdk/overlay)
 
@@ -126,7 +126,7 @@ Also note, the SDK itself and its documentation uses the utterly confusing termi
 
 - [x] [Current User Update](https://discord.com/developers/docs/game-sdk/users#oncurrentuserupdate)
 
-### :warning: Deprecation
+### ⚠️ Deprecation
 
 This hasn't been officially announced by Discord yet, but the [Voice](#voice), [Lobbies](#lobbies), and [Networking](#networking) functionality will be deprecated and removed sometime in the future. Since only the lobbies functionality has been implemented thusfar, we will mark that functionality as [`deprecated`](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute) once it is official.
 
@@ -159,14 +159,14 @@ We welcome community contributions to this project.
 Please read our [Contributor Guide](CONTRIBUTING.md) for more information on how to get started.
 Please also read our [Contributor Terms](CONTRIBUTING.md/#Contributor-Terms) before you make any contributions.
 
-Any contribution intentionally submitted for inclusion in an Embark Studios project, shall comply with the Rust standard licensing model (MIT + Apache 2.0) and therefore be dual licensed as described below, without any additional terms or conditions:
+Any contribution intentionally submitted for inclusion in an Embark Studios project, shall comply with the Rust standard licensing model (MIT OR Apache 2.0) and therefore be dual licensed as described below, without any additional terms or conditions:
 
 ### License
 
-This [contribution] is dual licensed under EITHER OF
+This contribution is dual licensed under EITHER OF
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/sdk/src/handler/wheel.rs
+++ b/sdk/src/handler/wheel.rs
@@ -94,7 +94,7 @@ where
     F: Fn(crate::Error) + Send + Sync,
 {
     async fn on_error(&self, error: crate::Error) {
-        self(error)
+        self(error);
     }
 }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,30 +1,39 @@
 //! See <https://github.com/discord/discord-rpc/blob/master/documentation/hard-mode.md>
 //! for details on the protocol
 
-// BEGIN - Embark standard lints v0.3
+// BEGIN - Embark standard lints v0.4
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 #![deny(unsafe_code)]
 #![warn(
     clippy::all,
     clippy::await_holding_lock,
+    clippy::char_lit_as_u8,
+    clippy::checked_conversions,
     clippy::dbg_macro,
     clippy::debug_assert_with_mut_call,
     clippy::doc_markdown,
     clippy::empty_enum,
     clippy::enum_glob_use,
     clippy::exit,
+    clippy::expl_impl_clone_on_copy,
+    clippy::explicit_deref_methods,
     clippy::explicit_into_iter_loop,
+    clippy::fallible_impl_from,
     clippy::filter_map_next,
+    clippy::float_cmp_const,
     clippy::fn_params_excessive_bools,
     clippy::if_let_mutex,
+    clippy::implicit_clone,
     clippy::imprecise_flops,
     clippy::inefficient_to_string,
+    clippy::invalid_upcast_comparisons,
     clippy::large_types_passed_by_value,
     clippy::let_unit_value,
     clippy::linkedlist,
     clippy::lossy_float_literal,
     clippy::macro_use_imports,
+    clippy::manual_ok_or,
     clippy::map_err_ignore,
     clippy::map_flatten,
     clippy::map_unwrap_or,
@@ -33,48 +42,34 @@
     clippy::match_wildcard_for_single_variants,
     clippy::mem_forget,
     clippy::mismatched_target_os,
+    clippy::mut_mut,
+    clippy::mutex_integer,
     clippy::needless_borrow,
     clippy::needless_continue,
     clippy::option_option,
-    clippy::pub_enum_variant_names,
+    clippy::path_buf_push_overwrite,
+    clippy::ptr_as_ptr,
     clippy::ref_option_ref,
     clippy::rest_pat_in_fully_bound_structs,
+    clippy::same_functions_in_if_condition,
+    clippy::semicolon_if_nothing_returned,
     clippy::string_add_assign,
     clippy::string_add,
+    clippy::string_lit_as_bytes,
     clippy::string_to_string,
-    clippy::suboptimal_flops,
     clippy::todo,
+    clippy::trait_duplication_in_bounds,
     clippy::unimplemented,
     clippy::unnested_or_patterns,
     clippy::unused_self,
+    clippy::useless_transmute,
     clippy::verbose_file_reads,
+    clippy::zero_sized_map_values,
     future_incompatible,
     nonstandard_style,
     rust_2018_idioms
 )]
-// END - Embark standard lints v0.3
-// BEGIN - Ark-specific lints
-#![warn(
-    clippy::ptr_as_ptr,
-    clippy::path_buf_push_overwrite,
-    clippy::explicit_deref_methods,
-    clippy::expl_impl_clone_on_copy,
-    clippy::zero_sized_map_values,
-    clippy::invalid_upcast_comparisons,
-    clippy::float_cmp_const,
-    clippy::checked_conversions,
-    clippy::char_lit_as_u8,
-    clippy::fallible_impl_from,
-    clippy::trait_duplication_in_bounds,
-    clippy::wrong_pub_self_convention,
-    clippy::same_functions_in_if_condition,
-    clippy::mut_mut,
-    clippy::string_lit_as_bytes,
-    clippy::useless_transmute,
-    clippy::manual_ok_or,
-    clippy::mutex_integer
-)]
-// END - Ark-specific lints
+// END - Embark standard lints v0.4
 // crate-specific exceptions:
 #![allow()]
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,6 +1,4 @@
-//! See <https://github.com/discord/discord-rpc/blob/master/documentation/hard-mode.md>
-//! for details on the protocol
-
+#![doc = include_str!("../README.md")]
 // BEGIN - Embark standard lints v0.4
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>


### PR DESCRIPTION
This hasn't been officially announced by Discord yet, but the Voice, Lobbies, and Networking functionality will be deprecated and removed sometime in the future. Since only the lobbies functionality has been implemented thusfar, we will mark that functionality as [`deprecated`](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute) once it is official.