### PR TITLE
Fix relationship_update activity

### DIFF
--- a/examples/repl/Cargo.toml
+++ b/examples/repl/Cargo.toml
@@ -10,4 +10,5 @@ doctest = false
 
 [dev-dependencies]
 examples-shared = { path = "../../examples-shared" }
+shell-words = "1.0"
 structopt = "0.3"

--- a/examples/repl/examples/repl.rs
+++ b/examples/repl/examples/repl.rs
@@ -39,9 +39,9 @@ enum LobbyCmd {
 
 #[derive(StructOpt, Debug)]
 struct ActivityUpdateCmd {
-    #[structopt(long, default_value = "")]
+    #[structopt(long, default_value = "repling")]
     state: String,
-    #[structopt(long, default_value = "")]
+    #[structopt(long, default_value = "having fun")]
     details: String,
     /// Sets the start timestamp to the current system time
     #[structopt(long)]

--- a/examples/repl/examples/repl.rs
+++ b/examples/repl/examples/repl.rs
@@ -39,9 +39,9 @@ enum LobbyCmd {
 
 #[derive(StructOpt, Debug)]
 struct ActivityUpdateCmd {
-    #[structopt(long, default_value = "repling")]
+    #[structopt(long, default_value = "")]
     state: String,
-    #[structopt(long, default_value = "having fun")]
+    #[structopt(long, default_value = "")]
     details: String,
     /// Sets the start timestamp to the current system time
     #[structopt(long)]

--- a/examples/repl/examples/repl.rs
+++ b/examples/repl/examples/repl.rs
@@ -175,9 +175,18 @@ async fn main() -> Result<(), anyhow::Error> {
         line.clear();
 
         let _ = std::io::stdin().read_line(&mut line);
+        // Remove trailing newline
         line.pop();
 
-        match Cmd::from_iter_safe(std::iter::once("repl").chain(line.split(' '))) {
+        let split = match shell_words::split(&line) {
+            Ok(sl) => sl,
+            Err(e) => {
+                tracing::error!("failed to split command: {}", e);
+                continue;
+            }
+        };
+
+        match Cmd::from_iter_safe(std::iter::once("repl".to_owned()).chain(split.into_iter())) {
             Ok(cmd) => {
                 if let Cmd::Exit = &cmd {
                     break;

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#14](https://github.com/EmbarkStudios/discord-sdk/pull/14) fixed an issue where the `RELATIONSHIP_UPDATE` event actually uses stringized timestamps in the activity information, rather than the normal `i64` timestamps in eg `SET_ACTIVITY`.
+- [PR#14](https://github.com/EmbarkStudios/discord-sdk/pull/14) fixed an issue with timestamps being converted into `chrono::DateTime<Utc>` with the wrong unit, resulting in date times far in the future.
+- [PR#14](https://github.com/EmbarkStudios/discord-sdk/pull/14) added more sanitization to `crate::activity::ActivityBuilder` to prevent strings with just whitespace being sent to Discord as that results in API failures.
+
 ## [0.1.1] - 2021-07-28
 ### Added
 - [PR#10](https://github.com/EmbarkStudios/discord-sdk/pull/10) added `ActivityBuilder::start_timestamp` and `ActivityBuilder::end_timestamp` as well as implementing `IntoTimestamp` for `i64`. Thanks [@Ewpratten](https://github.com/Ewpratten)!

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -58,3 +58,4 @@ winreg = "0.9"
 [dev-dependencies]
 # So tests can print out tracing
 tracing-subscriber = "0.2"
+insta = "1.7"

--- a/sdk/src/activity.rs
+++ b/sdk/src/activity.rs
@@ -683,13 +683,19 @@ impl crate::Discord {
 /// so we just truncate them manually client side to avoid sending more data
 #[inline]
 fn truncate(text: Option<impl Into<String>>, name: &str) -> Option<String> {
-    text.map(|text| {
+    text.and_then(|text| {
         let mut text = text.into();
         if text.len() > 128 {
             tracing::warn!("{} '{}' is too long and will be truncated", name, text);
             text.truncate(128);
         }
 
-        text
+        // Ensure the strings don't have just whitespace, as they are also not
+        // allowed
+        if text.trim().is_empty() {
+            None
+        } else {
+            Some(text)
+        }
     })
 }

--- a/sdk/src/activity/events.rs
+++ b/sdk/src/activity/events.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 #[derive(Deserialize, Debug, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct SecretEvent {
     pub secret: String,
 }
@@ -9,12 +10,20 @@ pub struct SecretEvent {
 ///
 /// [API docs](https://discord.com/developers/docs/game-sdk/activities#onactivityjoinrequest)
 #[derive(Deserialize, Debug, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct JoinRequestEvent {
-    #[serde(deserialize_with = "crate::user::de_user")]
     pub user: crate::user::User,
 }
 
-pub type InviteEvent = std::sync::Arc<crate::activity::ActivityInvite>;
+#[derive(Deserialize, Debug, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
+pub struct InviteEvent(pub std::sync::Arc<crate::activity::ActivityInvite>);
+
+impl AsRef<crate::activity::ActivityInvite> for InviteEvent {
+    fn as_ref(&self) -> &crate::activity::ActivityInvite {
+        &self.0
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum ActivityEvent {

--- a/sdk/src/lobby.rs
+++ b/sdk/src/lobby.rs
@@ -48,6 +48,7 @@ pub enum LobbyKind {
 
 /// The voice states that can be attached to each lobby member
 #[derive(Deserialize, Debug, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct VoiceState {
     pub channel_id: crate::types::ChannelId,
     pub deaf: bool,
@@ -61,6 +62,7 @@ pub struct VoiceState {
 }
 
 #[derive(Deserialize, Debug, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct Lobby {
     /// The unique identifier for the lobby.
     pub id: LobbyId,
@@ -91,9 +93,9 @@ pub struct Lobby {
 }
 
 #[derive(Deserialize, Debug, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct LobbyMember {
     pub metadata: Metadata,
-    #[serde(deserialize_with = "crate::user::de_user")]
     pub user: crate::user::User,
     #[serde(skip)]
     pub speaking: bool,

--- a/sdk/src/lobby/events.rs
+++ b/sdk/src/lobby/events.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 #[derive(Deserialize, Debug, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct SpeakingEvent {
     /// The lobby with the voice channel
     pub lobby_id: LobbyId,
@@ -9,6 +10,7 @@ pub struct SpeakingEvent {
 }
 
 #[derive(Deserialize, Debug, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct MemberEvent {
     /// The lobby where the member state changed
     pub lobby_id: LobbyId,
@@ -17,6 +19,7 @@ pub struct MemberEvent {
 }
 
 #[derive(Deserialize, Debug, Clone)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct MessageEvent {
     /// The lobby the messsage was sent to
     pub lobby_id: LobbyId,

--- a/sdk/src/overlay/events.rs
+++ b/sdk/src/overlay/events.rs
@@ -2,6 +2,7 @@ use super::Visibility;
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct UpdateEvent {
     /// Whether the user has the overlay enabled or disabled. If the overlay
     /// is disabled, all the functionality of the SDK will still work. The

--- a/sdk/src/proto/event.rs
+++ b/sdk/src/proto/event.rs
@@ -44,6 +44,7 @@ pub(crate) enum EventKind {
 /// ```
 #[derive(Deserialize, Debug)]
 #[serde(tag = "evt", content = "data", rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, derive(Serialize))]
 pub enum Event {
     /// Fires when we've done something naughty and Discord is telling us to stop.
     ///
@@ -143,6 +144,7 @@ pub enum Event {
 /// }
 /// ```
 #[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(Serialize))]
 pub(crate) struct EventFrame {
     /// The actual data payload, we don't care about "cmd" or "nonce" since
     /// nonce is not set for events and cmd is always `DISPATCH`.

--- a/sdk/src/snapshots/discord_sdk__activity__test__serde.snap
+++ b/sdk/src/snapshots/discord_sdk__activity__test__serde.snap
@@ -1,0 +1,31 @@
+---
+source: sdk/src/activity.rs
+expression: cmd
+
+---
+{
+  "cmd": "SET_ACTIVITY",
+  "nonce": "2",
+  "args": {
+    "pid": 9999,
+    "activity": {
+      "details": "deetz",
+      "timestamps": {
+        "start": 1628629161811,
+        "end": 1628629327961
+      },
+      "party": {
+        "id": "parrrrty",
+        "size": [
+          1,
+          2
+        ],
+        "privacy": 0
+      },
+      "secrets": {
+        "join": "sekret"
+      },
+      "instance": false
+    }
+  }
+}

--- a/sdk/src/snapshots/discord_sdk__relations__test__serde.snap
+++ b/sdk/src/snapshots/discord_sdk__relations__test__serde.snap
@@ -1,0 +1,39 @@
+---
+source: sdk/src/relations.rs
+expression: eve
+
+---
+{
+  "evt": "RELATIONSHIP_UPDATE",
+  "data": {
+    "type": 1,
+    "user": {
+      "id": "123414231424",
+      "username": "name",
+      "discriminator": "52",
+      "avatar": "f62f2a755cb18c94dc5cda94441024f1",
+      "bot": false
+    },
+    "presence": {
+      "status": "dnd",
+      "activity": {
+        "session_id": "6bb1ddaea510750e905615286709d632",
+        "state": "Rob Curly",
+        "details": "To the Moon",
+        "timestamps": {
+          "start": "1628629161811",
+          "end": "1628629327961"
+        },
+        "assets": {
+          "large_image": "spotify:ab67616d0000b273d1e326d10706f3d8562d77f8",
+          "large_text": "To the Moon"
+        },
+        "party": {
+          "id": "spotify: 216453179196440576"
+        },
+        "type": 2,
+        "instance": false
+      }
+    }
+  }
+}

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -29,7 +29,7 @@ pub(crate) struct ErrorPayloadStack<'stack> {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[cfg_attr(test, derive(serde::Serialize))]
+#[cfg_attr(test, derive(Serialize))]
 #[serde(rename_all = "snake_case")]
 pub enum Environment {
     Production,
@@ -37,7 +37,7 @@ pub enum Environment {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[cfg_attr(test, derive(serde::Serialize))]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DiscordConfig {
     /// The CDN host that can be used to retrieve user avatars
     pub cdn_host: String,

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -11,6 +11,7 @@ pub(crate) struct CloseFrame<'frame> {
 }
 
 #[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ErrorPayload {
     code: Option<u32>,
     message: Option<String>,
@@ -28,6 +29,7 @@ pub(crate) struct ErrorPayloadStack<'stack> {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[cfg_attr(test, derive(serde::Serialize))]
 #[serde(rename_all = "snake_case")]
 pub enum Environment {
     Production,
@@ -35,6 +37,7 @@ pub enum Environment {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct DiscordConfig {
     /// The CDN host that can be used to retrieve user avatars
     pub cdn_host: String,

--- a/sdk/src/user/events.rs
+++ b/sdk/src/user/events.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 #[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct ConnectEvent {
     /// The protocol version, we only support v1, which is fine since that is
     /// (currently) the only version
@@ -8,14 +9,14 @@ pub struct ConnectEvent {
     pub version: u32,
     pub config: crate::types::DiscordConfig,
     /// The user that is logged into the Discord application we connected to
-    #[serde(deserialize_with = "crate::user::de_user")]
     pub user: User,
 }
 
 #[derive(Deserialize, Debug)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct UpdateEvent {
     /// The user that is logged into the Discord application we connected to
-    #[serde(flatten, deserialize_with = "crate::user::de_user")]
+    #[serde(flatten)]
     pub user: User,
 }
 


### PR DESCRIPTION
Gives relationship_update events their own activity type to avoid future differences between the formats, still sharing some types though.

Also fixes an issue where timestamps converted from Discord's i64 representation, which is in milliseconds, but was converted as if it was in seconds. :stuck_out_tongue: 

Also fixes an issue where the strings such as `state` and `details` in the `SET_ACTIVITY` command must either be null/missing or else have something other than whitespace.

Resolves: #13 