### PR TITLE
Add empty implementation

### DIFF
--- a/sdk/src/registration.rs
+++ b/sdk/src/registration.rs
@@ -5,6 +5,14 @@
 #[cfg_attr(target_os = "linux", path = "registration/linux.rs")]
 #[cfg_attr(target_os = "windows", path = "registration/windows.rs")]
 #[cfg_attr(target_os = "macos", path = "registration/mac.rs")]
+#[cfg_attr(
+    all(
+        not(target_os = "linux"),
+        not(target_os = "windows"),
+        not(target_os = "macos")
+    ),
+    path = "registration/empty.rs"
+)]
 mod registrar;
 
 use crate::Error;

--- a/sdk/src/registration/empty.rs
+++ b/sdk/src/registration/empty.rs
@@ -1,0 +1,5 @@
+use crate::Error;
+
+pub fn register_app(_app: super::Application) -> Result<(), Error> {
+    Ok(())
+}


### PR DESCRIPTION
Add an empty `register_app` implementation so that discord-sdk can be compiled on all platforms, even if it doesn't actually function on them.