### PR TITLE
Implement buttons

### DIFF
--- a/examples/activity/examples/activity.rs
+++ b/examples/activity/examples/activity.rs
@@ -22,6 +22,11 @@ async fn main() -> Result<(), anyhow::Error> {
                 .large("the".to_owned(), Some("u mage".to_owned()))
                 .small("the".to_owned(), Some("i mage".to_owned())),
         )
+        .with_buttons()
+        .button(ds::activity::Button {
+            label: "discord-sdk by EmbarkStudios".to_owned(),
+            url: "https://github.com/EmbarkStudios/discord-sdk".to_owned(),
+        })
         .start_timestamp(SystemTime::now());
 
     tracing::info!(

--- a/examples/repl/examples/repl.rs
+++ b/examples/repl/examples/repl.rs
@@ -376,6 +376,7 @@ async fn main() -> Result<(), anyhow::Error> {
                                         std::num::NonZeroU32::new(2),
                                         activity::PartyPrivacy::Private,
                                     )
+                                    .with_secrets()
                                     .secrets(ds::activity::Secrets {
                                         join: Some("joinme".to_owned()),
                                         spectate: Some("spectateme".to_owned()),

--- a/sdk/tests/activity.rs
+++ b/sdk/tests/activity.rs
@@ -65,6 +65,7 @@ async fn test_activity() {
                     std::num::NonZeroU32::new(2),
                     activity::PartyPrivacy::Public,
                 )
+                .with_secrets()
                 .secrets(activity::Secrets {
                     join: Some("muchsecretverysecurity".to_owned()),
                     ..Default::default()


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
- [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
- [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

I implemented support for buttons.
This is a breaking change, because it adds a new field to the `Activity` struct and changes how secrets are added.
When both `secrets` and `buttons` are set, discord will respond with an error that the fields are exclusive.
I've made some changes to represent that in the type system in `ActivityBuilder` via a generic.

The API for everything besides secrets and buttons stays the same.
If a user wants to set the secrets they will have to call `with_secrets()` first and are only able to do that on the returned struct.
The same behaviour is implemented for buttons but with `with_buttons()`.

Discord responds with a different structure for the buttons than it expects in the request.
I didn't want to duplicate the Activity struct, so I did that with being generic over the Button type.
Because of a [bug in rust](https://github.com/rust-lang/rust/issues/26925) I had to implement Default manually.

### Related Issues

- https://github.com/EmbarkStudios/discord-sdk/issues/23
