### PR TITLE
feat: allow builder to set ActivityKind

### DIFF
--- a/sdk/src/activity.rs
+++ b/sdk/src/activity.rs
@@ -813,6 +813,7 @@ mod test {
                 join: Some("sekret".to_owned()),
                 ..Default::default()
             })
+            .kind(ActivityKind::Listening)
             .into();
 
         let cmd = crate::proto::Rpc {

--- a/sdk/src/activity.rs
+++ b/sdk/src/activity.rs
@@ -593,6 +593,20 @@ impl ActivityBuilder {
         }
         self
     }
+
+    /// Set the kind of this activity.
+    pub fn kind(mut self, kind: ActivityKind) -> Self {
+        match &mut self.inner.activity {
+            Some(activity) => activity.kind = kind,
+            None => {
+                self.inner.activity = Some(Activity {
+                    kind,
+                    ..Default::default()
+                });
+            }
+        }
+        self
+    }
 }
 
 impl crate::Discord {

--- a/sdk/src/snapshots/discord_sdk__activity__test__serde.snap
+++ b/sdk/src/snapshots/discord_sdk__activity__test__serde.snap
@@ -25,7 +25,7 @@ expression: cmd
       "secrets": {
         "join": "sekret"
       },
-      "type": 0,
+      "type": 2,
       "instance": false
     }
   }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This pr adds a simple method to the `ActivityBuilder` that allows setting the `ActivityKind` field of the underlying `ActivityArgs`.
The test case testing the builder has been updated to utilize this new method.

### Additional Notes/Questions

- The links to the contributor guide and the coc in the pr template don't work
- Should I update the docs somewhere to point out that not all `ActivityKind` types are supported?
We could link to [here](https://discord.com/developers/docs/topics/rpc#setactivity-set-activity-argument-structure), but I'm not sure where I should put this.
- Should I run `cargo update`?
I don't think it'll cause any issues and dependencies should be kept up to date

### Related Issues

#38 allowed for serialization of this field, so I think it's only logical to allow it to be set in the builder as well.