### PR TITLE
Make `discord-sdk` run even if there is no tokio runtime

### DIFF
--- a/sdk/src/handler.rs
+++ b/sdk/src/handler.rs
@@ -32,7 +32,7 @@ pub(crate) fn handler_task(
     mut rrx: tokio::sync::mpsc::Receiver<io::IoMsg>,
     state: crate::State,
 ) -> tokio::task::JoinHandle<()> {
-    tokio::task::spawn(async move {
+    crate::runtime::tokio_runtime().spawn(async move {
         tracing::debug!("starting handler loop");
 
         let pop_nonce = |nonce: usize| -> Option<crate::NotifyItem> {
@@ -46,7 +46,7 @@ pub(crate) fn handler_task(
         // Shunt the user handler to a separate task so that we don't care about it blocking
         // when handling events
         let (user_tx, mut user_rx) = tokio::sync::mpsc::unbounded_channel();
-        let user_task = tokio::task::spawn(async move {
+        let user_task = crate::runtime::tokio_runtime().spawn(async move {
             while let Some(msg) = user_rx.recv().await {
                 handler.on_message(msg).await;
             }
@@ -248,7 +248,7 @@ fn process_frame(data_buf: Vec<u8>) -> Msg {
 }
 
 fn subscribe_task(subs: crate::Subscriptions, stx: cc::Sender<Option<Vec<u8>>>) {
-    tokio::task::spawn(async move {
+    crate::runtime::tokio_runtime().spawn(async move {
         // Assume a max of 64KiB write size and just write all of the
         // subscriptions into a single buffer rather than n
         let mut buffer = Vec::with_capacity(1024);

--- a/sdk/src/io.rs
+++ b/sdk/src/io.rs
@@ -219,7 +219,7 @@ pub(crate) fn start_io_task(app_id: i64) -> IoTask {
     // The io thread also sends messages
     let io_stx = stx.clone();
 
-    let handle = tokio::task::spawn(async move {
+    let handle = crate::runtime::tokio_runtime().spawn(async move {
         async fn io_loop(
             stream: impl SocketStream,
             app_id: i64,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -12,6 +12,7 @@ pub mod registration;
 pub mod relations;
 mod types;
 pub mod user;
+pub mod runtime;
 
 pub use error::{DiscordApiErr, DiscordErr, Error};
 pub use handler::{handlers, wheel, DiscordHandler, DiscordMsg};

--- a/sdk/src/runtime.rs
+++ b/sdk/src/runtime.rs
@@ -1,8 +1,7 @@
 use std::sync::OnceLock;
 use tokio::runtime::Runtime;
 
-/// Tokio runtime, use this if you want to use async code inside bevy systems
-pub fn tokio_runtime() -> &'static Runtime {
+pub(crate) fn tokio_runtime() -> &'static Runtime {
     static RUNTIME: OnceLock<Runtime> = OnceLock::new();
     RUNTIME.get_or_init(|| Runtime::new().expect("Setting up tokio runtime needs to succeed."))
 }

--- a/sdk/src/runtime.rs
+++ b/sdk/src/runtime.rs
@@ -1,0 +1,8 @@
+use std::sync::OnceLock;
+use tokio::runtime::Runtime;
+
+/// Tokio runtime, use this if you want to use async code inside bevy systems
+pub fn tokio_runtime() -> &'static Runtime {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| Runtime::new().expect("Setting up tokio runtime needs to succeed."))
+}

--- a/sdk/tests/activity.rs
+++ b/sdk/tests/activity.rs
@@ -14,7 +14,7 @@ async fn test_activity() {
     let shared::DualClients { one, two } = dual;
 
     let mut events = one.events;
-    tokio::task::spawn(async move {
+    ds::runtime::tokio_runtime().spawn(async move {
         while let Some(event) = events.recv().await {
             tracing::debug!(which = 1, event = ?event);
         }
@@ -24,7 +24,7 @@ async fn test_activity() {
     let (join_tx, join_rx) = tokio::sync::oneshot::channel();
 
     let mut events = two.events;
-    tokio::task::spawn(async move {
+    ds::runtime::tokio_runtime().spawn(async move {
         let mut invite_tx = Some(invite_tx);
         let mut join_tx = Some(join_tx);
         while let Some(event) = events.recv().await {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Now, this SDK can be used even in application without `#[tokio::main]`. This could be useful in environments like bevy where you generally don't use `#[tokio::main]` on the `main` function

### Related Issues

In order to use this sdk, `#[tokio::main]` needed to be on the `main` function
